### PR TITLE
Utilize the new Ruby orb.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   coveralls: coveralls/coveralls@1.0.4
+  ruby: circleci/ruby@1.0
 
 jobs:
   build:
@@ -9,15 +10,8 @@ jobs:
       - image: cimg/ruby:2.6.5-node
     steps:
       - checkout
-      - run:
-          name: Install Bundler
-          command: gem install bundler:2.1.4
-      - run:
-          name: Install dependencies with bundler
-          command: bundle install
-      - run:
-          name: Run tests
-          command: bundle exec rspec
+      - ruby/install-deps
+      - ruby/rspec-test
       - coveralls/upload:
           path_to_lcov: ./coverage/lcov/project.lcov
           


### PR DESCRIPTION
- Installs bundler (version 2.1.4 by default) and installs and caches dependencies by default.
- Rspec test command is pre-configured for test splitting, allowing the user to simply enable parallelism and tests will be split based on timing data from previous runs.

[wait for tests]